### PR TITLE
Remove session notes from menu

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -26,11 +26,6 @@ publishDir = "docs"
     weight = 10
 
   [[menu.main]]
-    name = "Session Notes"
-    url = "sessions/"
-    weight = 20
-
-  [[menu.main]]
     name = "Partners"
     url = "partners/"
     weight = 40


### PR DESCRIPTION
Session notes don't add much value because there is a lot of unnecessary details. We will instead migrate to having project pages where people can get up-to-speed on particular projects and find the contact information for volunteers working on that project.