### PR TITLE
bump hugo build action to latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@v2
     - name: build
-      uses: jakejarvis/hugo-build-action@v0.73.0
+      uses: jakejarvis/hugo-build-action@v0.80.0
       with:
         args: -d build
     - name: deploy


### PR DESCRIPTION
looks like the errors mentioned by #8 are caused by deprecated packages in version of jakejarvis/hugo-build-action we were using, so let's try upgrading it

edit: confirmed fixes #8 