### PR TITLE
add dependabot

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
closes #10 

should keep the actions we use in our build/deploy workflow up to date and avoid future problems related to versioning