### PR TITLE
add dependabot to .github folder

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily

--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: daily


### PR DESCRIPTION
the documentation wasn't specific on where to put the configuration file, so I (foolishly) assumed that meant to put it in the root of the project.

well, by chance i happened across a button to enable dependabot in the web UI here and it wanted to put the configuration in .github instead. so here we are.