### PR TITLE
only run deploy step on master

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,8 @@ jobs:
           args: -d build
       - name: deploy
         uses: JamesIves/github-pages-deploy-action@releases/v3
+        # Only run the deploy step on master
+        if: github.ref == 'refs/heads/master'
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages


### PR DESCRIPTION
Related to CI failures like [this](https://github.com/phillycommunitywireless/phillycommunitywireless/actions/runs/2968592799/jobs/4899029760) and [this](https://github.com/phillycommunitywireless/phillycommunitywireless/actions/runs/2974600585/jobs/4765497829).

@addiebarron or @hawc2, I'm assuming we only want to deploy the site off of `master`, so I have a config change that I think/hope will mean that the `deploy` step of the build job gets skipped unless it's running for `master`.

That said, if we don't already, it'd probably be good to add something that lets us preview changes on a branch without redeploying the site.