### PR TITLE
Hamburger navigation menu for mobile devices.

### DIFF
--- a/assets/pcw-hugo-theme/css/custom.css
+++ b/assets/pcw-hugo-theme/css/custom.css
@@ -177,8 +177,8 @@ img.opos-top {
   width: 2rem;
   height: 2rem;
   position: absolute;
-  top: 15px;
-  right: 15px;
+  top: 32px;
+  right: 16px;
   cursor: pointer;
 }
 

--- a/assets/pcw-hugo-theme/css/custom.css
+++ b/assets/pcw-hugo-theme/css/custom.css
@@ -167,3 +167,47 @@ img.opos-top {
   height: 100px;
   object-fit: contain;
 }
+
+/*Hamburger style menu for mobile devices*/
+#hamburger-menu
+{
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  width: 2rem;
+  height: 2rem;
+  position: absolute;
+  top: 15px;
+  right: 15px;
+  cursor: pointer;
+}
+
+#hamburger-menu div
+{
+  width: 2rem;
+  height: 0.25rem;
+  background: white;
+}
+
+/*Show hamburger menu on small screens*/
+@media (max-width: 600px)
+{
+  #hamburger-menu
+  {
+    display: flex;
+  }
+}
+
+/*Hide hamburger menu on large screens*/
+@media (min-width: 601px)
+{
+  #site-menu
+  {
+    display: block !important; /*automatically displays nav items if width becomes >600px*/
+  }
+  
+  #hamburger-menu 
+  {
+    display: none !important;
+  }
+}

--- a/assets/pcw-hugo-theme/css/custom.css
+++ b/assets/pcw-hugo-theme/css/custom.css
@@ -195,6 +195,7 @@ img.opos-top {
   #hamburger-menu
   {
     display: flex;
+    transition: transform 0.3s ease-in-out;
   }
 }
 
@@ -211,3 +212,8 @@ img.opos-top {
     display: none !important;
   }
 }
+
+.rotate {
+  transform: rotate(90deg);
+}
+

--- a/themes/pcw-hugo-theme/layouts/partials/site-navigation.html
+++ b/themes/pcw-hugo-theme/layouts/partials/site-navigation.html
@@ -1,11 +1,18 @@
+
 <nav class="bg-pcw pa2 pl3-ns" role="navigation">
   <div class="flex-l justify-between items-center center">
     <a href="{{ .Site.Home.RelPermalink }}" class="f3 fw2 hover-white no-underline white-90 flex items-center">
       <img height="70" src="{{ $.Site.Params.site_logo }}" alt="{{ $.Site.Title }}"/>
     </a>
+    <!-- Hamburger style menu. Only applies to devices with <=600px width -->
+    <div id="hamburger-menu" class="dn db-l">
+      <div></div>
+      <div></div>
+      <div></div>
+    </div>
     <div class="flex-l items-center">
       {{ if .Site.Menus.main }}
-      <ul class="ph0 mb0-s lh-copy">
+      <ul id="site-menu" class="ph0 mb0-s lh-copy dn-l">
         {{ range .Site.Menus.main }}
         <li class="list f4 fw4 dib pr4 pr3-s pt2 pb1">
           <a class="hover-white no-underline white-90" href="{{ .URL | absLangURL }}" title="{{ .Name }} page">
@@ -19,3 +26,15 @@
     </div>
   </div>
 </nav>
+
+<!--Script to show/hide navigation content-->
+<script>
+  document.getElementById('hamburger-menu').addEventListener('click', function() {
+    var siteMenu = document.getElementById('site-menu');
+    if (siteMenu.style.display === 'none') {
+      siteMenu.style.display = 'block';
+    } else {
+      siteMenu.style.display = 'none';
+    }
+  });
+</script>

--- a/themes/pcw-hugo-theme/layouts/partials/site-navigation.html
+++ b/themes/pcw-hugo-theme/layouts/partials/site-navigation.html
@@ -33,11 +33,15 @@
   var siteMenu = document.getElementById('site-menu');
   var hamburgerMenu = document.getElementById('hamburger-menu');
 
-  // Update state when hamburger menu is clicked
-  hamburgerMenu.addEventListener('click', function() {
-    //Check if nav items are visible, if so then hamburger should be vertical
-    var isNavVisible = getComputedStyle(siteMenu).display !== 'none';
+  //Set initial state of hamburger menu based on visibility of navigation
+  var isNavVisible = getComputedStyle(siteMenu).display !== 'none';
+  if (isNavVisible) {
+    hamburgerMenu.classList.add('rotate');
+  }
 
+  //Update state when hamburger menu is clicked
+  hamburgerMenu.addEventListener('click', function() {
+    isNavVisible = getComputedStyle(siteMenu).display !== 'none';
     if (isNavVisible) {
       siteMenu.classList.add('dn');
       hamburgerMenu.classList.remove('rotate');

--- a/themes/pcw-hugo-theme/layouts/partials/site-navigation.html
+++ b/themes/pcw-hugo-theme/layouts/partials/site-navigation.html
@@ -29,12 +29,23 @@
 
 <!--Script to show/hide navigation content-->
 <script>
-  document.getElementById('hamburger-menu').addEventListener('click', function() {
-    var siteMenu = document.getElementById('site-menu');
-    if (siteMenu.style.display === 'none') {
-      siteMenu.style.display = 'block';
+  //stores the most recent status of the hamburger menu for mobile nav
+  var siteMenu = document.getElementById('site-menu');
+  var hamburgerMenu = document.getElementById('hamburger-menu');
+
+  // Update state when hamburger menu is clicked
+  hamburgerMenu.addEventListener('click', function() {
+    //Check if nav items are visible, if so then hamburger should be vertical
+    var isNavVisible = getComputedStyle(siteMenu).display !== 'none';
+
+    if (isNavVisible) {
+      siteMenu.classList.add('dn');
+      hamburgerMenu.classList.remove('rotate');
+      localStorage.setItem('menuShown', 'false');
     } else {
-      siteMenu.style.display = 'none';
+      siteMenu.classList.remove('dn');
+      hamburgerMenu.classList.add('rotate');
+      localStorage.setItem('menuShown', 'true');
     }
   });
 </script>

--- a/themes/pcw-hugo-theme/layouts/partials/site-navigation.html
+++ b/themes/pcw-hugo-theme/layouts/partials/site-navigation.html
@@ -33,15 +33,14 @@
   var siteMenu = document.getElementById('site-menu');
   var hamburgerMenu = document.getElementById('hamburger-menu');
 
-  //Set initial state of hamburger menu based on visibility of navigation
-  var isNavVisible = getComputedStyle(siteMenu).display !== 'none';
-  if (isNavVisible) {
-    hamburgerMenu.classList.add('rotate');
+  //Hide menu content on small screens by default
+  if (window.innerWidth <= 600) {
+    siteMenu.classList.add('dn');
   }
 
   //Update state when hamburger menu is clicked
   hamburgerMenu.addEventListener('click', function() {
-    isNavVisible = getComputedStyle(siteMenu).display !== 'none';
+    var isNavVisible = getComputedStyle(siteMenu).display !== 'none';
     if (isNavVisible) {
       siteMenu.classList.add('dn');
       hamburgerMenu.classList.remove('rotate');


### PR DESCRIPTION
Addressing issue #106 the navigation panel would become cumbersome when accessing the site on a mobile device. These changes implement a variable hamburger style menu for devices with a width of <=600px aka mobile devices.

The hamburger menu will act differently depending on the width of the browser as well as whether or not the navigation menu is active or not. For example, when active the icon will display vertically.

![PCW Menu](https://github.com/phillycommunitywireless/phillycommunitywireless/assets/143641814/17b9a485-c82b-4a77-9043-d80fe53e03d7)

And when the navigation menu is hidden will rotate back horizontally.

![Screenshot_1](https://github.com/phillycommunitywireless/phillycommunitywireless/assets/143641814/26fcd10a-68ca-4cdf-9535-901a3bca6036)

Additionally, these options will apply to any web browser that has been narrowed to under 600px.

![Screenshot_3](https://github.com/phillycommunitywireless/phillycommunitywireless/assets/143641814/dd01c199-f807-40ae-98b3-b9064d6d12a9)

And automatically restore the banner when sized above 600px in width. This is done based on the css code found in custom.css pertaining to the max and min-widths.