### PR TITLE
Add aria-label to the calendar iframe

### DIFF
--- a/content/en/volunteer.md
+++ b/content/en/volunteer.md
@@ -50,4 +50,4 @@ If you’re interested in getting involved, please fill out our [Volunteer Sign-
 
 ## Event Calendar
 
-<iframe src="https://calendar.google.com/calendar/embed?src=c_ca84146424d3ddad9678df590065af38e3fc78ff3720a41ed05584cd5e7cd7eb%40group.calendar.google.com&ctz=America%2FNew_York" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+<iframe src="https://calendar.google.com/calendar/embed?src=c_ca84146424d3ddad9678df590065af38e3fc78ff3720a41ed05584cd5e7cd7eb%40group.calendar.google.com&ctz=America%2FNew_York" style="border: 0" width="800" height="600" frameborder="0" scrolling="no" aria-label="Event Calendar"></iframe>


### PR DESCRIPTION
Fixes #168. 

Tested with Mac VoiceOver that the new label "Event Calendar" is read.

I'll note that the Spanish version of the page doesn't have the calendar iframe at all. Should we add it there too?