### PR TITLE
Fix contrast in nav links and footer. 

### DIFF
--- a/assets/pcw-hugo-theme/css/custom.css
+++ b/assets/pcw-hugo-theme/css/custom.css
@@ -262,7 +262,11 @@ img.opos-top {
 }
 
 /* alt color on hover for navbar menu items */
-.submenu li:hover, #site-menu li:hover {
+.submenu li:hover, #site-menu li:hover, #translations li:hover {
   background-color: #7a87f5;
   transition: 0.5s;
+}
+
+footer {
+  border-color: var(--primary);
 }

--- a/themes/pcw-hugo-theme/layouts/partials/i18nlist.html
+++ b/themes/pcw-hugo-theme/layouts/partials/i18nlist.html
@@ -1,8 +1,8 @@
 {{ if .IsTranslated }}
 <ul id="translations" class="pl0 mr3-l db-l dn">
     {{ range .Translations }}
-    <li class="list f4 fw4 dib pr3-l pt2 pb1">
-        <a class="hover-white no-underline white-50" href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a>
+    <li class="list f4 fw4 dib br3 pt2 pb1">
+        <a class="hover-white no-underline white" href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a>
     </li>
     {{ end}}
 </ul>

--- a/themes/pcw-hugo-theme/layouts/partials/site-footer.html
+++ b/themes/pcw-hugo-theme/layouts/partials/site-footer.html
@@ -1,11 +1,11 @@
 {{/* Include CSS for fonts here since this is HTML, not a markdown template */}}.
 <link href="/fontawesome/css/all.min.css" rel="stylesheet">
 
-<footer class="pv2 ph3 ph5-m ph6-l {{ .Site.Params.background_color_class | default " bg-black-80" }}"
+<footer class="pv2 ph3 ph5-m ph6-l bg-black-80 bg-white bt"
   role="contentinfo">
   <div class="flex f4 p2 m-footer justify-between">
     <span class="self-center" style="margin-right: 2vw" id="footer-logo">
-      <a class="f3 fw2 hover-white no-underline white-90 flex items-center" href="{{ .Site.Home.RelPermalink }}">
+      <a class="f3 fw2 hover-white no-underline white flex items-center" href="{{ .Site.Home.RelPermalink }}">
         <img alt="{{ $.Site.Title }}" height="70" src="{{ $.Site.Params.site_logo_inverted }}" />
       </a>
 

--- a/themes/pcw-hugo-theme/layouts/partials/site-navigation.html
+++ b/themes/pcw-hugo-theme/layouts/partials/site-navigation.html
@@ -1,6 +1,6 @@
 <nav class="bg-pcw pa2 pl3-ns" role="navigation">
   <div class="flex-l justify-between items-center center">
-    <a href="{{ .Site.Home.RelPermalink }}" class="f3 fw2 hover-white no-underline white-90 flex items-center">
+    <a href="{{ .Site.Home.RelPermalink }}" class="f3 fw2 hover-white no-underline white flex items-center">
       <img height="70" src="{{ $.Site.Params.site_logo }}" alt="{{ $.Site.Title }}" />
     </a>
     <!-- Hamburger style menu. Only applies to devices with <=600px width -->
@@ -15,13 +15,13 @@
         {{ range .Site.Menus.main }}
         {{ if .HasChildren }}
         <li class="list br3 f4 fw4 dib mr4-l pt2 pb1 relative d-flex justify-center">
-          <a class="no-underline white-90 dropdown-toggle" href="javascript:void(0)"
+          <a class="no-underline white dropdown-toggle" href="javascript:void(0)"
             title="{{ .Name }} page">
             {{ .Name }} <span class="dropdown-arrow fa-solid fa fa-caret-down"></span>
           </a>
           <ul style="top: 40px" class="absolute shadow-1 dn submenu bg-pcw br3 ph2">
             {{ range .Children }}
-            <a style="white-space: nowrap;" class="hover-white no-underline white-90 pa0" href="{{ .URL | relLangURL }}" title="{{ .Name }} page">
+            <a style="white-space: nowrap;" class="hover-white no-underline white pa0" href="{{ .URL | relLangURL }}" title="{{ .Name }} page">
               <li class="list f4 fw4 br3 grow dim justify-center pv2 ph2">
                   {{ .Name }}
               </li>
@@ -30,8 +30,8 @@
           </ul>
         </li>
         {{ else }}
-        <li class="list f4 fw4 dib br3 mr4-l pt2 pb1 dim justify-center">
-          <a class="hover-white no-underline white-90" href="{{ .URL | relLangURL }}" title="{{ .Name }} page">
+        <li class="list f4 fw4 dib br3 mr4-l pt2 pb1 justify-center">
+          <a class="hover-white no-underline white" href="{{ .URL | relLangURL }}" title="{{ .Name }} page">
             {{ .Name }}
           </a>
         </li>


### PR DESCRIPTION
Fixes #163.

* Changes the header nav links to be white instead of white-50.
* Changes the nav links to also be white on hover.
* Changes the translation link (the español/english button) to also be white, and to have the same background color effect as the other links.
* Makes the footer background white.
* Adds a border-top to the footer to distinguish it from the rest of the page.

This one's a lot of little changes, def worth manually testing.