### PR TITLE
Add alt text to website images

### DIFF
--- a/content/en/about/getting-here.md
+++ b/content/en/about/getting-here.md
@@ -8,9 +8,9 @@ aliases:
 
 PCW is located at the [Norris Square Neighborhood Project](http://myneighborhoodproject.org/) at 2141 N Howard Street, adjacent to Norris Square Park. 
 
-{{< figure class="figure-center" src="/images/nsnp.png">}}  
+{{< figure class="figure-center" src="/images/nsnp.png" alt="Map of Norris Square Park and the surrounding streets with marker for 2141 Howard Street, the Norris Square Neighborhood Project.">}}  
 
-{{< figure class="figure-center" src="/map/images/nsnp.jpg">}}  
+{{< figure class="figure-center" src="/map/images/nsnp.jpg" alt="Exterior of 2141 N Howard St Building with Norris Square Park Neighboorhood Project sign.">}}  
 
 ## Public Transit 
 NSNP is a quick walk from either the York-Dauphin or Berks Market-Frankford Line SEPTA stops. 

--- a/content/en/about/people/alexwc.md
+++ b/content/en/about/people/alexwc.md
@@ -6,6 +6,6 @@ aliases:
     - /alexwc
 ---
 
-{{< figure class="figure-center" src="/images/AlexWC_Portrait.jpg" width=200 height=200 >}}  
+{{< figure class="figure-center" src="/images/AlexWC_Portrait.jpg" alt="Headshot of Alex Wermer-Colan." width=200 height=200 >}}  
 
 Alex Wermer-Colan is a co-founder, long-time volunteer, and Executive Director of Philly Community Wireless. A resident of North Philadelphia, Alex also works as the Academic and Research Director at Temple University Libraries' Loretta C. Duckworth Scholars Studio. 

--- a/content/en/about/people/chrism.md
+++ b/content/en/about/people/chrism.md
@@ -7,6 +7,6 @@ aliases:
 
 ---
 
-{{< figure class="figure-center" src="/images/ChrisMTabling-Square.jpg" width=200 height=200 >}}  
+{{< figure class="figure-center" src="/images/ChrisMTabling-Square.jpg" width=200 height=200 alt="Headshot of Chris Mehretab." >}}  
 
 Originally from Harrisburg, PA, Chris initially joined the PCW team as an Intern in the Summer of 2021. From there, his work grew as the Community Engagement Liaison, into his current role as Content Coordinator. He has assisted in multiple outreach forums including canvassing, tabling for community events, and operating all PCW related social media channels. Outside of PCW, Chris works at a law firm in the city and enjoys DJing and playing with his cat Puffin.

--- a/content/en/about/people/eugener.md
+++ b/content/en/about/people/eugener.md
@@ -6,6 +6,6 @@ aliases:
     - /eugener
 ---
 
-{{< figure class="figure-center" src="/images/EugeneRHeadshot-Square.jpg" width=200 height=200  >}}  
+{{< figure class="figure-center" src="/images/EugeneRHeadshot-Square.jpg" width=200 height=200 alt="Headshot of Eugene Ryoo." >}}  
 
 Eugene is the Technician with Philly Community Wireless. He grew up in central Pennsylvania and moved to Philadelphia in the summer of 2022. Primarily interested in the relationship between people and technology, Eugene's role include leading installations, writing and maintaining web applications, and creating documentation. Outside of work, Eugene enjoys going to shows, playing guitar and bass, cycling, and hanging out at home with his cat, Toes.

--- a/content/en/about/people/leannep.md
+++ b/content/en/about/people/leannep.md
@@ -6,7 +6,7 @@ aliases:
     - /leannep
 ---
 
-{{< figure class="figure-center" src="/images/LeannePHeadshot-Square.jpg" width=200 height=200 >}}  
+{{< figure class="figure-center" src="/images/LeannePHeadshot-Square.jpg" width=200 height=200 alt="Headshot of Leanne Przybylowski.">}}  
 
 A Canadian, Leanne came to Philadelphia in 2021 to pursue a Master’s of Science in Communication for Development and Social Change at Temple University. Interested in digital equity and the link between digital spaces and healthy democracy, Leanne began volunteering with PCW in Summer 2023, quickly becoming quite active in the organization and passionate about its alternative vision for transforming digital inclusion through community wifi. She is excited to learn and grow alongside community members, local leaders, and her colleagues.  
 

--- a/content/en/about/people/zoek.md
+++ b/content/en/about/people/zoek.md
@@ -6,6 +6,6 @@ aliases:
     - /zoek
 ---
 
-{{< figure class="figure-center" src="/images/ZoeKHeadshot-Square.jpg" width=200 height=200  >}}  
+{{< figure class="figure-center" src="/images/ZoeKHeadshot-Square.jpg" width=200 height=200 alt="Headshot of Zoe Kerrich." >}}  
 
 Zoe began volunteering with Philly Community Wireless in the summer of 2024, and currently supports wifi access installation work. She has a background in city and regional planning, with a focus in climate resilience planning. Outside of work, Zoe enjoys gardening, biking, and weaving.

--- a/content/es/about/getting-here.md
+++ b/content/es/about/getting-here.md
@@ -8,9 +8,9 @@ aliases:
 
 PCW is located at the [Norris Square Neighborhood Project](http://myneighborhoodproject.org/) at 2141 N Howard Street, adjacent to Norris Square Park. 
 
-{{< figure class="figure-center" src="/images/nsnp.png">}}  
+{{< figure class="figure-center" src="/images/nsnp.png" alt="Mapa de Norris Square Park y las calles circundantes con marcador para 2141 Howard Street, el Proyecto del Vecindario Norris Square.">}}  
 
-{{< figure class="figure-center" src="/map/images/nsnp.jpg">}}  
+{{< figure class="figure-center" src="/map/images/nsnp.jpg" alt="Exterior del edificio 2141 N Howard St con el cartel del Proyecto Vecinal de Norris Square Park.">}}  
 
 ## Public Transit 
 NSNP is a quick walk from either the York-Dauphin or Berks Market-Frankford Line SEPTA stops. 

--- a/content/es/about/people/alexwc.md
+++ b/content/es/about/people/alexwc.md
@@ -6,6 +6,6 @@ aliases:
     - /es/alexwc
 ---
 
-{{< figure class="figure-center" src="/images/AlexWCHeadshot-Square.jpg" width=200 height=200 >}}  
+{{< figure class="figure-center" src="/images/AlexWCHeadshot-Square.jpg" width=200 height=200 alt="Foto de rostro de Alex Wermer-Colan." >}}  
 
 Alex Wermer-Colan es cofundador, voluntario desde hace mucho tiempo y director ejecutivo de Philly Community Wireless. Alex, residente del norte de Filadelfia, también trabaja como director académico y de investigación en el Loretta C. Duckworth Scholars Estudio de las Bibliotecas de la Universidad de Temple.  

--- a/content/es/about/people/chrism.md
+++ b/content/es/about/people/chrism.md
@@ -7,7 +7,7 @@ aliases:
     - /es/chrism/
 ---
 
-{{< figure class="figure-center" src="/images/ChrisMTabling-Square.jpg" width=200 height=200 >}}  
+{{< figure class="figure-center" src="/images/ChrisMTabling-Square.jpg" width=200 height=200 alt="Foto de rostro de Chris Mehretab." >}}  
 
 Originario de Harrisburg, PA, Chris se unió inicialmente al equipo de PCW como pasante en el verano de 2021. A partir de ahí, su trabajo creció como enlace de participación comunitaria hasta su puesto actual como coordinador de contenidos. Ha ayudado en múltiples foros de divulgación, incluido el sondeo, la presentación de eventos comunitarios y la operación de todos los canales de redes sociales relacionados con PCW. Fuera de PCW, Chris trabaja en un bufete de abogados de la ciudad y le gusta pinchar y jugar con su gato Puffin.  
 

--- a/content/es/about/people/eugener.md
+++ b/content/es/about/people/eugener.md
@@ -6,6 +6,6 @@ aliases:
     - /es/eugener
 ---
 
-{{< figure class="figure-center" src="/images/EugeneRHeadshot-Square.jpg" width=200 height=200  >}}    
+{{< figure class="figure-center" src="/images/EugeneRHeadshot-Square.jpg" width=200 height=200 alt="Foto de rostro de Eugene Ryoo." >}}    
 
 Eugene es líder de instalación en Philly Community Wireless. Creció en el centro de Pensilvania y se mudó a Filadelfia en el verano de 2022. Principalmente interesado en la relación entre las personas y la tecnología, Eugene hace un poco de todo con PCW, desde ayudar con las instalaciones hasta escribir y mantener aplicaciones web. Fuera del trabajo, a Eugene le gusta ir a espectáculos, tocar la guitarra y el bajo, andar en bicicleta y pasar el rato en casa con su gato, Toes.  

--- a/content/es/about/people/leannep.md
+++ b/content/es/about/people/leannep.md
@@ -6,7 +6,7 @@ aliases:
     - /es/leannep
 ---
 
-{{< figure class="figure-center" src="/images/LeannePHeadshot-Square.jpg" width=200 height=200 >}}  
+{{< figure class="figure-center" src="/images/LeannePHeadshot-Square.jpg" width=200 height=200 alt="Foto de rostro de Leanne Przybylowski.">}}  
 
 Leanne, una canadiense, llegó a Filadelfia en 2021 para realizar una Maestría en Ciencias en Comunicación para el Desarrollo y el Cambio Social en la Universidad de Temple. Interesada en la equidad digital y el vínculo entre los espacios digitales y la democracia saludable, Leanne comenzó a trabajar como voluntaria en PCW al final de su tiempo en Temple y rápidamente se volvió muy activa en la organización y apasionada por su visión alternativa para transformar la inclusión digital a través del wifi comunitario.  
 

--- a/content/es/about/people/zoek.md
+++ b/content/es/about/people/zoek.md
@@ -7,6 +7,6 @@ aliases:
 
 ---
 
-{{< figure class="figure-center" src="/images/ZoeKHeadshot-Square.jpg" width=200 height=200  >}}  
+{{< figure class="figure-center" src="/images/ZoeKHeadshot-Square.jpg" width=200 height=200 alt="Foto de rostro de Zoe Kerrich." >}}  
 
 Zoe comenzó a trabajar como voluntaria en Philly Community Wireless en el verano de 2024, y actualmente apoya el trabajo de instalación de acceso wifi. Tiene formación en planificación urbana y regional, con especialización en planificación de la resiliencia climática. Fuera del trabajo, a Zoe le gusta la jardinería, montar en bicicleta y tejer.


### PR DESCRIPTION
Closing out the accessibility audit - looks like adding alt text bumps the Lighthouse scores from the mid-80s to 100! 

<img width="2689" height="1616" alt="image" src="https://github.com/user-attachments/assets/2ebfac8e-ec09-444c-9cab-ee105416c084" />
