### PR TITLE
Adjust breakpoints for resized images

### DIFF
--- a/themes/pcw-hugo-theme/layouts/partials/hero-header.html
+++ b/themes/pcw-hugo-theme/layouts/partials/hero-header.html
@@ -7,7 +7,7 @@
 
     <!-- concat default class + user inputs to preserve class styling -->
     {{ $class := printf "br3 ctr-img %s" .header_class }}
-    {{ partial "responsive-image.html" (dict "src" .header_photo "alt" .header_alt "class" $class "sizes" "(min-width: 60em) 50vw, 100vw") }}
+    {{ partial "responsive-image.html" (dict "src" .header_photo "alt" .header_alt "class" $class "sizes" "100vw") }}
 </div>
 {{ end }}
 {{ end }}

--- a/themes/pcw-hugo-theme/layouts/partials/responsive-image.html
+++ b/themes/pcw-hugo-theme/layouts/partials/responsive-image.html
@@ -40,15 +40,17 @@
   {{- $w := $res.Width -}}
   {{- $h := $res.Height -}}
   {{- $srcset := slice -}}
-  {{- range (slice 480 768 1024 1600) -}}
+  {{- range (slice 480 768 1024 1600 1920 2560 3840) -}}
     {{- if lt . $w -}}
-      {{- $r := $res.Resize (printf "%dx webp q80" .) -}}
+      {{- $r := $res.Resize (printf "%dx webp q90" .) -}}
       {{- $srcset = $srcset | append (printf "%s %dw" $r.RelPermalink .) -}}
     {{- end -}}
   {{- end -}}
-  {{- $full := $res.Resize (printf "%dx webp q80" $w) -}}
-  {{- $srcset = $srcset | append (printf "%s %dw" $full.RelPermalink $w) -}}
-  <img src="{{ $full.RelPermalink }}" srcset="{{ delimit $srcset ", " }}" sizes="{{ $sizes }}" width="{{ $w }}" height="{{ $h }}" alt="{{ $alt }}" loading="{{ $loading }}" decoding="async"{{ with $class }} class="{{ . }}"{{ end }}{{ with $style }} style="{{ . }}"{{ end }}>
+  {{- $capW := $w -}}
+  {{- if gt $w 3840 -}}{{- $capW = 3840 -}}{{- end -}}
+  {{- $full := $res.Resize (printf "%dx webp q90" $capW) -}}
+  {{- $srcset = $srcset | append (printf "%s %dw" $full.RelPermalink $capW) -}}
+  <img src="{{ $full.RelPermalink }}" srcset="{{ delimit $srcset ", " }}" sizes="{{ $sizes }}" width="{{ $full.Width }}" height="{{ $full.Height }}" alt="{{ $alt }}" loading="{{ $loading }}" decoding="async"{{ with $class }} class="{{ . }}"{{ end }}{{ with $style }} style="{{ . }}"{{ end }}>
 {{- else -}}
   <img src="{{ $src }}" alt="{{ $alt }}" loading="{{ $loading }}" decoding="async"{{ with $class }} class="{{ . }}"{{ end }}{{ with $style }} style="{{ . }}"{{ end }}>
 {{- end -}}


### PR DESCRIPTION
Fixes an issue with hero images in segment `hero-header.html` being compressed to 50vw, causing distortion and pixelation. Fixed by adding wider screen sizes to `responsive-image.html` + adjusting the sizes passed to in hero-header.html to reflect the fact that hero images will always take up 100% of the screen width

Current: 
<img width="1402" height="909" alt="image" src="https://github.com/user-attachments/assets/94deb45a-51da-4a11-841f-bbdce694314a" />

Fixed:
<img width="1402" height="951" alt="image" src="https://github.com/user-attachments/assets/c2f57e5f-14ba-4892-a8bc-2533fcfdb2e7" />
