### PR TITLE
Improve button color contrast for accessibility

### DIFF
--- a/assets/pcw-hugo-theme/css/colors.css
+++ b/assets/pcw-hugo-theme/css/colors.css
@@ -6,7 +6,7 @@
   --orange: rgb(255, 128, 0);
 
   --blue: #5262ed;
-  --lilac: #d48aff;
+  --lilac: #8B3DBD;
   --dark-blue: #123248;
   --light-gray: #e6e6e6;
 
@@ -29,7 +29,7 @@
 }
 
 .bg-pcw-salmon {
-  background-color: #FF665A;
+  background-color: #C23D32;
   color: white;
 }
 


### PR DESCRIPTION
## Summary

This PR improves the color contrast of the "Volunteer" and "Support" call-to-action buttons on the homepage to meet WCAG AA accessibility requirements.

### Changes
- Darkened the salmon button background color.
- Darkened the lilac button background color.
- Preserved the existing design while improving accessibility.

### Verification
- Verified using browser accessibility tools.
- Volunteer button contrast: 5.24:1
- Support button contrast: 5.99:1

### Screenshots

**Support button**
<img width="392" height="459" alt="Screenshot 2026-07-03 203141" src="https://github.com/user-attachments/assets/dcfb3d7f-4630-46ed-bc96-11ea7582f6a0" />

**Volunteer button**
<img width="408" height="510" alt="Screenshot 2026-07-03 203118" src="https://github.com/user-attachments/assets/299d94ef-6ba4-4e31-aee9-88d51a95e25b" />

Fixes #242
